### PR TITLE
abuild/ckit: enable thirdMode to be able to deconstruct with attack3, ref Unvanquished#1182, Unvanquished #544

### DIFF
--- a/configs/weapon/abuild.attr.cfg
+++ b/configs/weapon/abuild.attr.cfg
@@ -12,6 +12,7 @@ primaryAttackRate 500
 secondaryAttackRate 1000
 
 hasAltMode
+hasThirdMode
 isPurchasable
 
 //Additional variables

--- a/configs/weapon/ckit.attr.cfg
+++ b/configs/weapon/ckit.attr.cfg
@@ -13,4 +13,5 @@ infiniteAmmo
 primaryAttackRate 1000
 
 hasAltMode
+hasThirdMode
 isPurchasable


### PR DESCRIPTION
Counterpart to https://github.com/Unvanquished/Unvanquished/pull/1182

Enable thirdMode for granger and construction kit to be able to deconstruct with attack3, ref Unvanquished#1182, Unvanquished #544.

See https://github.com/Unvanquished/Unvanquished/issues/1180
See https://github.com/Unvanquished/Unvanquished/issues/544