### PR TITLE
Tweak ballistic weapon and flamer lighting effects

### DIFF
--- a/configs/missiles/flamer.model.cfg
+++ b/configs/missiles/flamer.model.cfg
@@ -1,10 +1,6 @@
 // display
 sound              models/weapons/flamer/fireloop
 
-dlight             200
-dlightColor        0.25 0.1 0.0
-dlightIntensity    0 // TODO: Find out if a value != 0 is necessary
-
 // impact
 impactMark         gfx/weapons/flamer/mark
 impactMarkSize     32

--- a/models/weapons/chaingun/weapon.cfg
+++ b/models/weapons/chaingun/weapon.cfg
@@ -8,9 +8,9 @@ crosshairSize      64
 
 primary
 {
-  flashDLight           50.0
-  flashDLightInt        6.0
-  flashDLightColor      1.0 1.0 0.0
+  flashDLight           100.0
+  flashDLightInt        1.2
+  flashDLightColor      1.0 0.73 0.38
   flashSound            0 models/weapons/chaingun/flash0
   flashSound            1 models/weapons/chaingun/flash1
   flashSound            2 models/weapons/chaingun/flash2

--- a/models/weapons/flamer/weapon.cfg
+++ b/models/weapons/flamer/weapon.cfg
@@ -12,8 +12,8 @@ posOffs           -2.0 6.0 8.5
 
 primary
 {
-  flashDLight           200.0
-  flashDLightInt        20.0
+  flashDLight           100.0
+  flashDLightInt        6.0
   flashDlightColor      0.25 0.1 0.0
   continuousFlash
 

--- a/models/weapons/mgturret/weapon.cfg
+++ b/models/weapons/mgturret/weapon.cfg
@@ -1,6 +1,8 @@
 primary
 {
-  flashDlightColor      1.0 1.0 0.0
+  flashDLight           100.0
+  flashDLightInt        0.5
+  flashDlightColor      1.0 0.3 0.3
   flashSound            0 sound/buildables/mgturret/attack1
 
   impactMark            8 gfx/weapons/lgun/mark

--- a/models/weapons/rifle/weapon.cfg
+++ b/models/weapons/rifle/weapon.cfg
@@ -10,9 +10,9 @@ posOffs           -8.0 6.0 6.8
 
 primary
 {
-  flashDLight           50.0
-  flashDLightInt        4.0
-  flashDLightColor      1.0 1.0 0.0
+  flashDLight           100.0
+  flashDLightInt        0.5
+  flashDlightColor      1.0 0.73 0.38
   flashSound            0 models/weapons/rifle/flash0
 
   impactMark            5 gfx/weapons/rifle/mark

--- a/models/weapons/shotgun/weapon.cfg
+++ b/models/weapons/shotgun/weapon.cfg
@@ -12,7 +12,9 @@ posOffs           -6.5 6.5 7.0
 
 primary
 {
-  flashDlightColor      1.0 1.0 0.0
+  flashDLight           100.0
+  flashDLightInt        2.4
+  flashDlightColor      1.0 0.73 0.38
   flashSound            0 models/weapons/shotgun/flash0
 
   impactMark            4 gfx/weapons/shotgun/mark

--- a/scripts/fire.particle
+++ b/scripts/fire.particle
@@ -77,7 +77,7 @@ particles/weapons/flamer/floorfire
 			rotation 0 0 -
 			bounce 0
 
-			dynamicLight 0 50 0 { .25 .25 0 }
+			dynamicLight 0 50 10 { .25 .1 0 }
 
 			lifeTime 500~60%
 		}
@@ -100,7 +100,7 @@ particles/weapons/flamer/floorfire
 			rotation 0 0 -
 			bounce 0
 
-			dynamicLight 0 50 0 { .25 .25 0 }
+			dynamicLight 500 100 20 { .25 .1 0 }
 
 			lifeTime 500~60%
 		}

--- a/scripts/flamer.particle
+++ b/scripts/flamer.particle
@@ -215,7 +215,7 @@ particles/weapons/flamer/muzzleflash
 			rotation 0 320~80 320~80
 			bounce .01
 
-			dynamicLight    0 300 0 { .25 .25 0 }
+			dynamicLight 50 100 100 { .25 .1 0 }
 
 			lifeTime 750                // keep synchronized with FLAMER_LIFETIME
 		}


### PR DESCRIPTION
### Flamer values

The point was to find something that looks hot, and not overly bright. And to fix the ground flames. And to use only one color for the flames on the ground and in the air.

I settled to rgb(0.25, 0.1, 0) because I think it looks good.

### Ballistic weapon values

I tried to keep the brightness subtle-ish.

For the color, I did look at the temperature reached inside the cartridge. [Some website](https://www.police-scientifique.com/Armes-a-feu/les-munitions) basically says good ammunition reach a bit less that 4000 K (the better the ammo the higher the value), so I picked 4000K on [that color scale](https://retourverslecinema.com/wp-content/uploads/2015/05/infographie-echelle-kelvin.png) and used that.

I'll probably make another PR for tweaks on energy weapons later.