### PR TITLE
gfx: use fitScreen on scope

### DIFF
--- a/scripts/scope.shader
+++ b/scripts/scope.shader
@@ -1,6 +1,6 @@
 gfx/weapons/scope
 {
-	noPicMip
+	fitScreen
 	{
 		clampmap gfx/weapons/scope/zoom
 		alphaGen vertex


### PR DESCRIPTION
No need to load the scope textures in full resolution if the screen is small.