### PR TITLE
Fix prifle and lcannon 2nd impacts (autosprite rework)

### DIFF
--- a/scripts/lcannon.particle
+++ b/scripts/lcannon.particle
@@ -265,7 +265,7 @@ particles/weapons/lcannon/impact_small
 			shader sync gfx/weapons/prifle/impact
 
 			displacement 0 0 0 ~1.5
-			normalDisplacement -2
+			normalDisplacement 1
 
 			velocityType normal
 			velocityDir linear

--- a/scripts/prifle.particle
+++ b/scripts/prifle.particle
@@ -38,7 +38,7 @@ particles/weapons/prifle/impact
 			shader sync gfx/weapons/prifle/impact
 
 			displacement 0 0 0 ~1.5
-			normalDisplacement -2
+			normalDisplacement 1
 
 			velocityType normal
 			velocityDir linear

--- a/scripts/prifle.shader
+++ b/scripts/prifle.shader
@@ -101,6 +101,7 @@ gfx/weapons/prifle/impact
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen vertex
 		alphaGen vertex
+		depthFade 5
 	}
 }
 


### PR DESCRIPTION
As of 0.54, the gfx/weapons/prifle/impact particles used for prifle and lcannon secondary impact effects were only visible at oblique angles due to being hidden by automatic depth fade. Without depth fade, they look bad, with hard-clipped edges, like the rifle/shotgun marks (see https://github.com/UnvanquishedAssets/res-weapons_src.dpkdir/pull/19).

Improve the situation by moving the particle a bit further from the surface and applying a small depth fade. Now the particle is visible, but the sprite is not clipped at edges so harshly.

This needs the autosprite rework so that the depth fade parameter is respected.

[prifleimpact20rstrsttsr.webm](https://github.com/user-attachments/assets/bf173cdb-ba0f-49bc-960d-12a84b328a16)
