### PR TITLE
chaingun: Adjust muzzle flash ejector bullet trajectory

### DIFF
--- a/scripts/chaingun.particle
+++ b/scripts/chaingun.particle
@@ -6,14 +6,14 @@ particles/weapons/chaingun/muzzleflash
 		{
 			model models/shells/rifle/shell.md3
 
-			displacement -5 -3 0 ~0
+			displacement 2 -1 -3 0
 
 			parentVelocityFraction .85
 
 			velocityType static_transform
 			velocityDir linear
 			velocityMagnitude 100
-			velocity -1 -3 0 ~10
+			velocity 1 -3 0 ~10
 
 			accelerationType static
 			accelerationDir linear


### PR DESCRIPTION
Now they go away from the center of the screen and are closer to where I think they should be emitted.

Before:
![unvanquished_2024-10-13_231843_000](https://github.com/user-attachments/assets/a9c99d07-db44-4554-ac4b-769fa7ae11a4)

After:
![unvanquished_2024-10-13_231813_000](https://github.com/user-attachments/assets/85e3f078-9eec-4666-acbb-8316fd6e2219)
