### PR TITLE
psaw: Add back crosshairSizeNoBorder

### DIFF
--- a/models/weapons/psaw/weapon.cfg
+++ b/models/weapons/psaw/weapon.cfg
@@ -5,6 +5,7 @@ idleSound         models/weapons/psaw/idle
 crosshair          gfx/feedback/crosshairs/psaw
 crosshairIndicator gfx/feedback/indicators/psaw
 crosshairSize      64
+crosshairSizeNoBorder 19.5
 
 primary
 {


### PR DESCRIPTION
This was mistakenly deleted when adding the new psaw.