### PR TITLE
Make ground fire shader entityMergable

### DIFF
--- a/scripts/firebomb.shader
+++ b/scripts/firebomb.shader
@@ -19,6 +19,7 @@ gfx/weapons/firebomb/fire
 
 	polygonOffset
 	cull none
+	entityMergable
 	sort nearest
 
 	imageMinDimension 64


### PR DESCRIPTION
Fixes https://github.com/Unvanquished/Unvanquished/issues/1495 (I assume; I don't use that graphics card any more) by allowing all flame sprites to be combined in one draw call.

I had imagined that maybe they were drawn separately so that different frames could have different animation frames. But in reality `animMap` ignores the entity `shaderTime` (although perhaps it shouldn't), so making the entities mergible doesn't change anything. The frames are already synchronized and it isn't really noticeable.