### PR TITLE
Adjustments to correctly render rocket missile model

### DIFF
--- a/configs/missiles/rocket.model.cfg
+++ b/configs/missiles/rocket.model.cfg
@@ -1,6 +1,6 @@
 // display
 model                models/missiles/rocket/rocket.iqm
-modelRotation        0 -90 0
+modelRotation        0 90 0
 
 trailSystem          trails/weapons/rocket/missile
 

--- a/scripts/rocket.shader
+++ b/scripts/rocket.shader
@@ -1,8 +1,8 @@
 models/missiles/rocket/rocket
 {
 	qer_editorImage models/missiles/rocket/rocket
+	// TODO: remove transparency/blending https://github.com/UnvanquishedAssets/res-weapons_src.dpkdir/issues/35
 	surfaceparm trans
-	cull none
 	imageMinDimension 128
 	{
 		diffuseMap models/missiles/rocket/rocket


### PR DESCRIPTION
- Use normal culling so back faces aren't drawn on top
- Update rotation angles since gamelogic is being fixed to use the correct coordinate system

See https://github.com/Unvanquished/Unvanquished/issues/3375.

Companion: https://github.com/Unvanquished/Unvanquished/pull/3377